### PR TITLE
Use ref btn

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import Divider from './components/Divider';
 import Movie from './components/Movie';
 import Sidenote from './components/Sidenote';
 import NeonButton from './components/NeonButton';
+import UseRefButton from './components/UseRefButton';
 
 //simulate fetching movie data
 import { getMovies } from './api/movies';
@@ -85,6 +86,14 @@ const App = () => {
           <div className='component-title'>{`<NeonButton />`}</div>
           <div className='component-wrapper'>
             <NeonButton label='Neon Btn' onClick={() => console.log('<NeonButton/> clicked!')} />
+          </div>
+        </section>
+
+        {/* USEREF BUTTON COMPONENT */}
+        <section className='component-section'>
+          <div className='component-title'>{`<UseRefButton />`}</div>
+          <div className='component-wrapper'>
+            <UseRefButton/>
           </div>
         </section>
 

--- a/src/components/ImageUpload.css
+++ b/src/components/ImageUpload.css
@@ -19,7 +19,7 @@
 }
 
 .imgUpload {
-  max-width: 142%;
+  max-width: 300px;
   height: auto;
   border-radius: 5px;
   box-shadow: mediumslateblue 0px 1px 7px 0px;

--- a/src/components/ImageUpload.tsx
+++ b/src/components/ImageUpload.tsx
@@ -13,7 +13,12 @@ const ImageUpload = ({ storage }: ImageUploadProps) => {
   const [imageUpload, setImageUpload] = useState<File|null>(null);
   const [imageList, setImageList] = useState<string[]>([]);
   const [isUploading, setIsUploading] = useState<boolean>(false);
-  const [somefin, toggle, exportableFunction] = useDisplayImageInfo();
+  const [
+    somefin,
+    toggle,
+    exportableFunction,
+    addZoomToCursor,
+  ] = useDisplayImageInfo();
   console.count(somefin?.nothin);
 
   useEffect(() => {
@@ -65,7 +70,16 @@ const ImageUpload = ({ storage }: ImageUploadProps) => {
             src={url}
             alt='memory snapshot'
             key={url + id}
+            id={url + id}
             onClick={exportableFunction}
+            onMouseEnter={() => {
+              const hiImFromTheDom = document.getElementById(`${url + id}`);
+              addZoomToCursor(hiImFromTheDom, 1.2);
+            }}
+            onMouseLeave={() => {
+              const hiImFromTheDom = document.getElementById(`${url + id}`);
+              if (hiImFromTheDom) hiImFromTheDom.style.transform = 'scale(1)';
+            }}
           />
         ))}
       </div>

--- a/src/components/UseRefButton.tsx
+++ b/src/components/UseRefButton.tsx
@@ -1,0 +1,25 @@
+import { useRef } from 'react';
+
+export default function UseRefButton() {
+  const buttonRef = useRef<null | HTMLButtonElement>(null);
+  const refCount = useRef<number>(0);
+
+  function handleClick() {
+    const btnRefStyle = buttonRef.current?.style;
+    if (btnRefStyle) {
+      btnRefStyle.transform = refCount.current % 2 === 0
+        ? 'translate3d(1px, -2px, 0px)'
+        : '';
+      btnRefStyle.boxShadow = refCount.current % 2 === 0
+        ? '0 0 8px 3px mediumspringgreen, 0 0 23px 1px #ff00ff'
+        : '';
+    }
+    refCount.current = refCount.current + 1;
+  }
+
+  return (
+    <button ref={buttonRef} onClick={handleClick}>
+      Click me
+    </button>
+  );
+}

--- a/src/weCanDoHooksNow/displayImageInfo.ts
+++ b/src/weCanDoHooksNow/displayImageInfo.ts
@@ -15,7 +15,42 @@ const useDisplayImageInfo = () => {
     setSomefin({ nothin: `${imFeelinLucky}` });
   };
 
-  return [somefin, toggle, exportableFunction] as const;
+  /**
+   * Hi, I'm addZoomToCursor and I'm fabulous.
+   * I take in an element from DOM and I add a magical zooming effect around the cursor. IT comes to life.
+   * I don't return anything you nerds <3 => VOID
+   */
+  const addZoomToCursor = (hoveredElement: HTMLElement | null, zoomFactor = 1.2): void => {
+    if (!hoveredElement) return;
+    //smooth zoom animations n such
+    hoveredElement.style.transition = 'transform 0.2s ease-out';
+    
+    const rect = hoveredElement.getBoundingClientRect();
+    document.addEventListener('mousemove', event => {
+      const mouseX = event.clientX - rect.left;
+      const mouseY = event.clientY - rect.top;
+      const centerX = rect.width / 2;
+      const centerY = rect.height / 2;
+      const deltaX = mouseX - centerX;
+      const deltaY = mouseY - centerY;
+      hoveredElement.style.transformOrigin = `${event.clientX}px ${event.clientY}px`;
+      
+      // Calculate the new scale value based on the mouse position
+      const distance = Math.sqrt(deltaX**2 + deltaY**2);
+      const scale = 1 + distance/100;
+      // const scale = Math.min(zoomFactor, 1 + distance/100);
+      
+      // Apply the new scaling to the element
+      hoveredElement.style.transform = `scale(${scale})`;
+    });
+  };
+
+  return [
+    somefin,
+    toggle,
+    exportableFunction,
+    addZoomToCursor,
+  ] as const;
 };
 
 export default useDisplayImageInfo;


### PR DESCRIPTION
practice adding useRef to handle button on click logic.

useRef can be useful in some cases verses using document.getElementById because of future DOM lookups being avoided by caching the dom reference

or transforming dom cached useRef images onHover using similar approach

chat gpt had this to say regarding performance:
it's perfectly fine to use document and getElementById to manipulate the DOM elements in a React component. However, there are some potential downsides to doing it this way:

It breaks the encapsulation of the component: Manipulating the DOM directly from a React component can make it harder to reason about the component's behavior and can make it more difficult to reuse the component in other contexts.

It can lead to performance problems: When you manipulate the DOM directly, React can't optimize the rendering process as effectively. This can lead to slower performance and increased memory usage.

Using useRef can help alleviate some of these issues. When you use useRef, React creates a reference to the DOM element that persists across renders. You can then use this reference to manipulate the DOM directly without breaking the encapsulation of the component.